### PR TITLE
Bump to MC 26.2, fix AMD HiZ patch for reverse-Z depth buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ hs_err_*.log
 replay_*.log
 *.hprof
 *.jfr
+
+# project specific
+
+voxy-dev/
+*.log

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,9 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1.2
-loader_version=0.19.2
-loom_version=1.16-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Mod Properties
 mod_version=1.0.1
@@ -17,4 +17,4 @@ maven_group=com.amdfix
 archives_base_name=amd-patch-for-voxy
 
 # Dependencies
-fabric_api_version=0.149.1+26.1.2
+fabric_api_version=0.155.2+26.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.19.3
 loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=com.amdfix
 archives_base_name=amd-patch-for-voxy
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/amdfix/patch/ShaderPatchUtil.java
+++ b/src/main/java/com/amdfix/patch/ShaderPatchUtil.java
@@ -21,9 +21,33 @@ public final class ShaderPatchUtil {
             "float sp = texelFetch(hizDepthSampler, ivec2(x, y), ml).r;";
 
     /**
-     * Replacement GLSL block. Values {@code <= 0.2f} are forced to {@code 1.0f}
-     * (far plane) so that driver-bogus near-zero reads cannot corrupt the
+     * Replacement GLSL block. Values {@code <= 0.2f} are forced to {@code FAR}
+     * (the far plane) so that driver-bogus near-zero reads cannot corrupt the
      * {@code REDUCTION} (min/max) operation used for HiZ occlusion culling.
+     * <p>
+     * Why use the {@code FAR} macro instead of a hardcoded {@code 1.0f}?
+     * <p>
+     * Minecraft 26.2 introduced a reversed depth buffer
+     * ("Rendering now uses a reversed depth buffer"), which changes the
+     * semantics of depth values. Voxy's HiZ shader adapts to both depth
+     * conventions via the {@code USE_REVERSE_Z} macro (see Voxy's
+     * {@code depthutils.glsl}):
+     * <ul>
+     *   <li><strong>Standard-Z</strong> (MC 26.1.2 and earlier):
+     *       {@code FAR = 1.0f}, {@code REDUCTION = max}. Setting bogus values
+     *       to {@code FAR} pushes {@code pointSample} to the far plane, so the
+     *       region reads as "empty/far away" and nodes are not culled
+     *       (conservative).</li>
+     *   <li><strong>Reverse-Z</strong> (MC 26.2+): {@code FAR = 0.0f},
+     *       {@code REDUCTION = min}. Setting bogus values to {@code FAR} pulls
+     *       {@code pointSample} to the far plane (0.0), so the region reads as
+     *       "empty/far away" and nodes are not culled (conservative).</li>
+     * </ul>
+     * The previous implementation hardcoded {@code 1.0f}, which in Reverse-Z
+     * mode equals {@code NEAR} (the near plane). Combined with
+     * {@code REDUCTION = min}, this made the region read as "full of nearby
+     * geometry", causing <em>every</em> node behind it to be culled and Voxy
+     * to appear completely disabled on MC 26.2+.
      * <p>
      * Threshold {@code 0.2f} was chosen because it covers:
      * <ul>
@@ -35,7 +59,7 @@ public final class ShaderPatchUtil {
     public static final String PATCHED_CODE = """
             float sp = texelFetch(hizDepthSampler, ivec2(x, y), ml).r;
             if (sp <= 0.2f) {
-                sp = 1.0f;
+                sp = FAR;
             }
             """;
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,8 +26,8 @@
 		}
 	],
 	"depends": {
-		"fabricloader": ">=0.19.2",
-		"minecraft": "~26.1.2",
+		"fabricloader": ">=0.19.3",
+		"minecraft": "~26.2",
 		"java": ">=25",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
## Summary

Update the mod to work with Minecraft 26.2 and fix the AMD HiZ occlusion culling patch for the new reverse-Z depth buffer introduced in MC 26.2.

## Changes

- **gradle.properties**: bump versions for MC 26.2 (loader 0.19.3, loom 1.17, fabric-api 0.155.2+26.2)
- **fabric.mod.json**: update minecraft and fabricloader dependency ranges
- **gradle-wrapper.properties**: upgrade Gradle to 9.5.1 (required by Loom 1.17)
- **ShaderPatchUtil.java**: replace hardcoded 1.0f with FAR macro to work with both standard-Z (MC 26.1.2) and reverse-Z (MC 26.2+) depth buffer conventions
- **.gitignore**: add voxy-dev/ and *.log entries

## Why the FAR macro?

Minecraft 26.2 introduced reverse-Z depth buffering. The previous hardcoded 1.0f equals FAR in standard-Z (correct) but NEAR in reverse-Z (causes over-culling, making Voxy appear disabled). Using the FAR macro from Voxy's depthutils.glsl automatically adapts to both modes.