### PR TITLE
 Update for Minecraft 26.2 and fix reverse-Z LOD culling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,19 +76,41 @@ public static final String ORIGINAL_LINE =
 public static final String PATCHED_CODE = """
     float sp = texelFetch(hizDepthSampler, ivec2(x, y), ml).r;
     if (sp <= 0.2f) {
-        sp = 1.0f;
+        sp = FAR;
     }
     """;
 ```
 
 ### Threshold rationale (`0.2f`)
 
-The value `0.2f` was chosen to cover:
+The value `0.2f` (compared against the **raw** sample) was chosen to cover:
 - Sky / empty pixels where depth reads as `0.0` (driver bug)
 - Close-up walls that are legitimate near-plane values
 - Driver noise on Polaris hardware
 
 **If you change this value, update the Javadoc in `ShaderPatchUtil` and the README.**
+
+### Why `FAR` instead of a literal `1.0f`
+
+Voxy's `voxy:util/depthutils.glsl` defines the depth convention two ways via the
+`USE_REVERSE_Z` compile flag:
+
+| | Standard depth | Reverse-Z (Minecraft 26.2) |
+|-------------|----------------|-----------------------------|
+| `NEAR`      | `0.0`          | `1.0`                       |
+| `FAR`       | `1.0`          | `0.0`                       |
+| `REDUCTION` | `max`          | `min`                       |
+
+Hardcoding `sp = 1.0f` only means "far plane" under **standard** depth. Under
+**reverse-Z** it pins bogus reads to the **near** plane, so the `min` reduction
+marks every distant region as occluded and **all LOD sections vanish**. The AMD
+driver returns raw near-zero values regardless of convention, so snapping
+near-zero samples to the `FAR` macro is correct in both cases and always errs
+toward rendering. `FAR` is in scope because `screenspace.glsl` imports
+`depthutils.glsl` before the patched line.
+
+**Do not replace `FAR` with a numeric literal** — it will break under whichever
+depth convention it wasn't written for.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ To fix the rendering corruption on AMD cards, this patch may need to alter or di
 
 ## Requirements
 
-- **Minecraft:** `26.1.2`
-- **Fabric Loader:** `>= 0.19.2`
+- **Minecraft:** `26.2`
+- **Fabric Loader:** `>= 0.19.3`
 - **Java:** `25`
 - **[Voxy](https://github.com/MCRcortex/voxy):** `>= 0.2.0`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,14 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1.2
-loader_version=0.19.2
-loom_version=1.16-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.3
 maven_group=com.amdfix
 archives_base_name=amd-patch-for-voxy
 
 # Dependencies
-fabric_api_version=0.149.1+26.1.2
+fabric_api_version=0.155.2+26.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/amdfix/patch/ShaderPatchUtil.java
+++ b/src/main/java/com/amdfix/patch/ShaderPatchUtil.java
@@ -21,21 +21,36 @@ public final class ShaderPatchUtil {
             "float sp = texelFetch(hizDepthSampler, ivec2(x, y), ml).r;";
 
     /**
-     * Replacement GLSL block. Values {@code <= 0.2f} are forced to {@code 1.0f}
-     * (far plane) so that driver-bogus near-zero reads cannot corrupt the
+     * Replacement GLSL block. Raw samples {@code <= 0.2f} are forced to Voxy's
+     * {@code FAR} macro so that driver-bogus near-zero reads cannot corrupt the
      * {@code REDUCTION} (min/max) operation used for HiZ occlusion culling.
      * <p>
-     * Threshold {@code 0.2f} was chosen because it covers:
+     * <strong>Why {@code FAR} and not a literal {@code 1.0f}:</strong> Voxy's
+     * {@code depthutils.glsl} defines the depth convention two ways depending on
+     * the {@code USE_REVERSE_Z} compile flag. Under standard depth {@code FAR}
+     * is {@code 1.0} and {@code REDUCTION} is {@code max}; under reverse-Z (used
+     * by Minecraft 26.2's renderer) {@code FAR} is {@code 0.0} and
+     * {@code REDUCTION} is {@code min}. Hardcoding {@code 1.0f} pins bogus reads
+     * to the <em>near</em> plane under reverse-Z, which makes the culler treat
+     * every distant region as occluded and hides all LOD sections. Using the
+     * {@code FAR} macro is correct in both conventions — the AMD driver returns
+     * raw near-zero values regardless of convention, so "snap near-zero to
+     * {@code FAR}" always errs toward rendering (conservative culling).
+     * <p>
+     * Threshold {@code 0.2f} (compared against the raw sample) covers:
      * <ul>
      *   <li>Sky/empty pixels where depth may read as {@code 0.0}</li>
      *   <li>Close-up walls that are legitimate near-plane values</li>
      *   <li>Noise introduced by the AMD Polaris driver bug</li>
      * </ul>
+     * {@code FAR} is defined in {@code voxy:util/depthutils.glsl}, which is
+     * imported by {@code screenspace.glsl} before this line, so it is always in
+     * scope at the injection point.
      */
     public static final String PATCHED_CODE = """
             float sp = texelFetch(hizDepthSampler, ivec2(x, y), ml).r;
             if (sp <= 0.2f) {
-                sp = 1.0f;
+                sp = FAR;
             }
             """;
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,8 +26,8 @@
 		}
 	],
 	"depends": {
-		"fabricloader": ">=0.19.2",
-		"minecraft": "~26.1.2",
+		"fabricloader": ">=0.19.3",
+		"minecraft": "~26.2",
 		"java": ">=25",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
  Bump toolchain and dependencies to target Minecraft 26.2:
  - minecraft 26.1.2 -> 26.2, fabric-loader 0.19.2 -> 0.19.3
  - loom 1.16 -> 1.17-SNAPSHOT, Gradle wrapper 9.4.1 -> 9.6.1 (loom 1.17 requires Gradle >= 9.5.0)
  - fabric.mod.json and README requirements updated to match Fix all LOD sections vanishing on 26.2. The HiZ depth clamp hardcoded `sp = 1.0f` assuming 1.0 is the far plane, which only holds under standard depth. Minecraft 26.2 uses reverse-Z, where FAR is 0.0 and the reduction flips to min, so the literal pinned bogus AMD reads to the near plane and the culler hid every distant region. Clamp to Voxy's FAR macro instead, which is correct under both depth conventions.