### PR TITLE
Update mod for Minecraft 26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ To fix the rendering corruption on AMD cards, this patch may need to alter or di
 
 ## Requirements
 
-- **Minecraft:** `26.1.2`
-- **Fabric Loader:** `>= 0.19.2`
+- **Minecraft:** `26.2`
+- **Fabric Loader:** `>= 0.19.3`
 - **Java:** `25`
 - **[Voxy](https://github.com/MCRcortex/voxy):** `>= 0.2.0`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1.2
-loader_version=0.19.2
+minecraft_version=26.2
+loader_version=0.19.3
 loom_version=1.16-SNAPSHOT
 
 # Mod Properties
@@ -17,4 +17,4 @@ maven_group=com.amdfix
 archives_base_name=amd-patch-for-voxy
 
 # Dependencies
-fabric_api_version=0.149.1+26.1.2
+fabric_api_version=0.158.0+26.2

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.19.2",
-		"minecraft": "~26.1.2",
+		"minecraft": "~26.2",
 		"java": ">=25",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
Bump the required Minecraft, Fabric Loader, and Fabric API versions to 26.2 in the project metadata and README. This keeps the mod aligned with the current supported game/runtime versions and ensures the published dependency requirements match the build configuration.